### PR TITLE
Run get-inputs in a virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 google-credentials.json
 psm-dashboard-config.json
+pip-selfcheck.json
+sample-output.json
+bin/
+include/
+lib/
+share/
+psm_reqs.py
+__pycache__/

--- a/get-inputs
+++ b/get-inputs
@@ -23,19 +23,19 @@
 
 """Make JSON input for the PSM dashboard, using data from various sources.
 
-Prerequisites:
+Start a virtualenv and install requirements.txt:
 
-  $ sudo pip3 install -U google-api-python-client
-  $ sudo pip3 install -U python-gflags 
-  $ sudo pip3 install -U oauth2client
-  $ sudo pip3 install -U PyGithub
+  $ virtualenv --python=python3.5 .
+  $ source bin/activate
+  $ pip install -U -r requirements.txt
 
   ## Edit the config file as needed.  Getting some values may be
   ## a bit of work: see https://gist.github.com/burnash/6771295 and
   ## https://developers.google.com/sheets/api/quickstart/python. 
   ## Note that you will need to have a Google account, and that
   ## account must have access to the spreadsheet whose ID you're
-  ## using as your "google_sheet_id."
+  ## using as your "google_sheet_id."  For the GitHub API key, grant it
+  ## access to the `public_repos` scope. 
   $ cp psm-dashboard-config.json.tmpl psm-dashboard-config.json
   $ your-favorite-editor psm-dashboard-config.json
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client
+python-gflags
+oauth2client
+PyGithub


### PR DESCRIPTION
Instead of installing dependencies with `sudo`, start a virtualenv and install dependencies from a `requirements.txt`.  

This involves adding quite a lot to the .gitignore and changing the documentation for setting up the `get-inputs` script.  It might be overkill, but I didn't want to install everything with `sudo` personally, so figured I'd write up what I did to use a virtualenv.