### PR TITLE
Fix browser sort bug, closing #11

### DIFF
--- a/burn-down.js
+++ b/burn-down.js
@@ -160,18 +160,18 @@
       .sort(function(a, b) {
         if (a.status === b.status) {
           if (a.completedDate === b.completedDate) {
-            return a.startDate > b.startDate;
+            return a.startDate > b.startDate ? 1 : -1;
           } else {
-            return a.completedDate > b.completedDate;
+            return a.completedDate > b.completedDate ? 1 : -1;
           }
         } else if (a.status === "NotStarted") {
-          return true;
+          return 1;
         } else if (b.status === "NotStarted") {
-          return false;
+          return -1;
         } else if (a.status === "InProgress") {
-          return true;
+          return 1;
         } else if (b.status === "InProgress") {
-          return false;
+          return -1;
         }
       });
 


### PR DESCRIPTION
Firefox is the only browser that seems to reliably accept returning true and false for sorting rather than 1, -1, and 0. This fixes the sorting so that the bars display correctly across browsers. Confirmed that this works in Chrome, Chromium developer build, and Safari. I don't have access to IE, but I can try and set up a VM if that's useful