### PR TITLE
Add toggle for feature descriptions, closes #12

### DIFF
--- a/burn-down.js
+++ b/burn-down.js
@@ -127,6 +127,13 @@
     }
     var width = +chartEl.style("width").replace(/(px)/g, "");
     var height = +chartEl.style("height").replace(/(px)/g, "");
+
+    var showFeatureDescriptions = d3.select(".container")
+      .classed("show-feature-descriptions");
+    if (showFeatureDescriptions) {
+      height += 800;
+    }
+
     var root = d3
       .select("#burn-down-chart")
       .append("svg")
@@ -245,6 +252,12 @@
       return "bar" + (statusClass || "");
     }
 
+    var textX = 10;
+
+    function textY(datum, index) {
+      return barY(datum, index) + (barHeight / 2);
+    }
+
     chartG
       .selectAll("rect.not-started")
       .data(featuresArray)
@@ -296,6 +309,20 @@
       .attr("fill", "#363636")
       .attr("text-anchor", "middle")
       .text("Today");
+
+    // Feature descriptions when toggled
+
+    if (showFeatureDescriptions) {
+      chartG
+        .selectAll("text.description")
+        .data(featuresArray)
+        .enter()
+        .append("text")
+        .attr("class", "description")
+        .attr("x", textX)
+        .attr("y", textY)
+        .text(function (d) { return d.description; });
+    }
 
     // Tooltips.
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -26,5 +26,12 @@
     window.addEventListener("resize", function () {
       renderCharts(data, d3);
     });
+
+    var descToggle = document.querySelector("#showFeatureDescriptions");
+    descToggle.addEventListener("change", function () {
+      d3.select(".container")
+        .classed("show-feature-descriptions", descToggle.checked);
+      renderCharts(data, d3);
+    });
   });
 })(window.d3);

--- a/index.html
+++ b/index.html
@@ -32,14 +32,23 @@
       bottom: 15px;
     }
 
-    .container > .chart:first-child {
+    #burn-down-chart {
       left: 15px;
       right: 35%;
     }
 
-    .container > .chart:nth-child(2) {
+    #features-pie-chart {
       right: 15px;
       left: 65%;
+    }
+
+    .show-feature-descriptions > #burn-down-chart,
+    .show-feature-descriptions > #features-pie-chart {
+      position: relative;
+      width: 100%;
+      min-height: 500px;
+      left: inherit;
+      right: inherit;
     }
 
     .legend {
@@ -51,7 +60,7 @@
       margin: 4px;
     }
 
-    .color {
+    .legend > input, .color {
       height: 16px;
       width: 16px;
       margin-right: 8px;
@@ -59,18 +68,18 @@
     }
 
     .not-started {
-      background: #6ee0d9;
-      fill: #6ee0d9;
+      background: #a6cee3;
+      fill: #a6cee3;
     }
 
     .in-progress {
-      background: #2a8424;
-      fill: #2a8424;
+      background: #1f78b4;
+      fill: #1f78b4;
     }
 
     .completed {
-      background: #5c2484;
-      fill: #5c2484;
+      background: #b2df8a;
+      fill: #b2df8a;
     }
 
     .axis .domain, .axis .tick {
@@ -81,6 +90,15 @@
     .bar {
       stroke: #444;
       cursor: pointer;
+    }
+
+    text.description {
+      stroke-width: 0;
+      dominant-baseline: central;
+      alignment-baseline: middle;
+      pointer-events: none;
+      font-size: 11px;
+      fill: #000;
     }
 
     .tooltip {
@@ -104,7 +122,7 @@
     }
 
     .darkBackground {
-      position: absolute;
+      position: fixed;
       display: none;
       background: rgba(100,100,100,50%);
       height: 100%;
@@ -180,8 +198,8 @@
       .legend {
         margin-left: 8px;
       }
-      .container > .chart:first-child,
-      .container > .chart:nth-child(2) {
+      #burn-down-chart,
+      #features-pie-chart {
         position: relative;
         width: 100%;
         min-height: 500px;
@@ -205,6 +223,7 @@
     <p>
       <span class="color completed"></span> Completed
     </p>
+    <input type="checkbox" id="showFeatureDescriptions"> Show Feature Descriptions
   </div>
   <div class="container">
     <div class="chart" id="burn-down-chart"></div>


### PR DESCRIPTION
Adds a toggle for displaying feature descriptions in each row, and also increasing the overall height of the chart so they are visible. Also uses lighter colors so that the text has more contrast over the rows without having the alter the font color, and changes the overlay position property to "fixed" so that it isn't stuck at the top of the frame when scrolling.

Demo (on Firefox):

![pr-12](https://user-images.githubusercontent.com/8291663/41104853-f9b15a1a-6a31-11e8-927c-7a00158b9d53.gif)
