### PR TITLE
Update Google Sheet range

### DIFF
--- a/psm-dashboard-config.json.tmpl
+++ b/psm-dashboard-config.json.tmpl
@@ -2,7 +2,7 @@
     "google_sheet_id": "1avMeCIiayaCcx8fDzldo3KEiRHyM2qjjBuCXWKRwyao",
     "google_sheet_client_id": "REPLACE_WITH_APPROPRIATE_VALUE.apps.googleusercontent.com",
     "google_sheet_client_secret": "REPLACE_WITH_GOOGLE_API_CLIENT_SECRET",
-    "google_sheet_range": "Features!A:J",
+    "google_sheet_range": "Features",
     "github_owner": "solutionguidance",
     "github_repository": "psm",
     "github_auth_token_secret": "REPLACE_WITH_GITHUB_AUTH_TOKEN",


### PR DESCRIPTION
Replaces #13 since I realized I don't currently have permissions to push to this repo. Changes the "google_sheet_range" value in the template JSON config file so that it doesn't hard code a set of columns, uses the entire sheet instead. This way the config file doesn't have to be updated with a new range each time a set of columns is added.