### PR TITLE
Show future roadmap on burndown, closes #8

### DIFF
--- a/burn-down.js
+++ b/burn-down.js
@@ -286,6 +286,16 @@
       .attr("y", barY)
       .attr("height", barHeight);
 
+    // Render opacity mask for washed-out colors on future dates
+
+    chartG
+      .append("rect")
+      .attr("class", "future-mask")
+      .attr("x", xScale(new Date(todayString)))
+      .attr("y", 0)
+      .attr("width", xScale(new Date(globalEndDate)) - xScale(new Date(todayString)))
+      .attr("height", chartHeight);
+
     // Render today line.
 
     var todayLineColor = "orange";

--- a/index.html
+++ b/index.html
@@ -194,6 +194,12 @@
       font-size: 10px;
     }
 
+    .future-mask {
+      pointer-events: none;
+      fill: white;
+      opacity: 0.6;
+    }
+
     @media screen and (max-width: 700px) {
       .legend {
         margin-left: 8px;


### PR DESCRIPTION
Adds a partially-transparent `rect` element after the today line so that future roadmap dates can be displayed in a washed-out color. The `rect` element ignores all pointer events so hover and click interactions are still applied to the feature bars.

I had initially misread the issue and thought this involved parsing the "Projected Phase" column which is why I thought I had questions. Here's an example of the update (with updated test data showing the bars going to an arbitrary date in June):

![issue-8-pr](https://user-images.githubusercontent.com/8291663/41192730-d266e7bc-6bc7-11e8-8a5f-64b289069cdc.gif)
