### PR TITLE
Update pym.js height on label toggle, closes #20

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -32,6 +32,7 @@
       d3.select(".container")
         .classed("show-feature-descriptions", descToggle.checked);
       renderCharts(data, d3);
+      pymChild.sendHeight();
     });
   });
 })(window.d3);


### PR DESCRIPTION
Toggling feature labels changes the height of the page, but because it isn't a resize event pym.js doesn't automatically update the iframe height. This adds a call to `sendHeight()` so that the iframe height is updated as well. Opening now since the bug will show up for #7 without it.

Before:
![issue-20-bug](https://user-images.githubusercontent.com/8291663/41192788-f351d102-6bc8-11e8-93ab-8b9fd6877efa.gif)

After:
![issue-20-fix](https://user-images.githubusercontent.com/8291663/41192791-f72fb9ec-6bc8-11e8-9d79-4fc7c746e773.gif)
