### PR TITLE
Update legend position, closes #18

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,20 +51,30 @@
       right: inherit;
     }
 
-    .legend {
+    .legend, .controls {
       font-size: 16px;
       margin-left: 32px;
     }
 
-    .legend > p {
-      margin: 4px;
+    .legend {
+      text-align: center;
+      margin-bottom: 16px;
     }
 
-    .legend > input, .color {
+    .legend > p {
+      margin: 4px;
+      display: inline-block;
+    }
+
+    .controls > input, .color {
       height: 16px;
       width: 16px;
       margin-right: 8px;
       display: inline-block;
+    }
+
+    .color {
+      vertical-align: middle;
     }
 
     .not-started {
@@ -195,7 +205,7 @@
     }
 
     @media screen and (max-width: 700px) {
-      .legend {
+      .legend, .controls {
         margin-left: 8px;
       }
       #burn-down-chart,
@@ -223,6 +233,8 @@
     <p>
       <span class="color not-started"></span> Not Started
     </p>
+  </div>
+  <div class="controls">
     <input type="checkbox" id="showFeatureDescriptions"> Show Feature Descriptions
   </div>
   <div class="container">


### PR DESCRIPTION
Moves the legend closer to the top with the elements centered and horizontally distributed so that it's more obvious it applies to both charts, rather than just the burndown chart. Keeps the feature label toggle close to the burndown chart.

<img width="929" alt="screen shot 2018-06-09 at 10 02 31 am" src="https://user-images.githubusercontent.com/8291663/41193000-6730b252-6bcc-11e8-94b5-3a2d3efede6f.png">
