### PR TITLE
Set future status from start date, closes #8

### DIFF
--- a/burn-down.js
+++ b/burn-down.js
@@ -226,6 +226,13 @@
 
     var barHeight = chartHeight / featuresArray.length;
 
+    var featureStartDate = function(feature) {
+      if (feature.startDate === null) {
+        return globalStartDate;
+      }
+      return new Date(feature.startDate);
+    }
+
     var barWidthNotStarted = function(feature) {
       var end = xScale(new Date(feature.startDate || todayString));
       var start = xScale(globalStartDate);
@@ -234,7 +241,7 @@
 
     var barWidthInProgress = function(feature) {
       var end = xScale(new Date(feature.completedDate || todayString));
-      var start = xScale(new Date(feature.startDate));
+      var start = xScale(featureStartDate(feature));
       return end - start;
     };
 
@@ -244,11 +251,12 @@
     };
 
     function barClass(d) {
-      var statusClass = {
-        NotStarted: " not-started",
-        InProgress: " in-progress",
-        Completed: " completed"
-      }[d.status];
+      var statusClass = " not-started";
+      if (d.startDate !== null) {
+        statusClass = " in-progress";
+      } else if (d.status === "Completed") {
+        statusClass = " completed";
+      }
       return "bar" + (statusClass || "");
     }
 
@@ -271,16 +279,12 @@
 
     chartG
       .selectAll(["rect.in-progress", "rect.completed"])
-      .data(
-        featuresArray.filter(function(f) {
-          return f.status !== "NotStarted";
-        })
-      )
+      .data(featuresArray)
       .enter()
       .append("rect")
       .attr("class", barClass)
       .attr("x", function(d) {
-        return xScale(new Date(d.startDate));
+        return xScale(featureStartDate(d));
       })
       .attr("width", barWidthInProgress)
       .attr("y", barY)
@@ -309,7 +313,8 @@
       .attr("y1", 0)
       .attr("y2", chartHeight + todayLineExtension)
       .attr("stroke-width", 2)
-      .attr("stroke", todayLineColor);
+      .attr("stroke", todayLineColor)
+      .style("pointer-events", "none");
 
     chartG
       .append("text")


### PR DESCRIPTION
This PR fixes the issues from the last one (#21), and instead of just extending the "Not Started" lines into the future it sets the "In Progress" state based the initial start date. The branch won't look any different until start and end dates in the future are populated in the spreadsheet, and until then the default end date is still the current date. I'm assuming updating those dates in the spreadsheet isn't in scope for this issue. I also set `pointer-events: none` on the today line so that it doesn't interfere with the hover state on the bars.

To make sure I understand the desired behavior, here's a demo that can be replicated on this branch by locally changing `psm-feature-039` in features-info.json to have a start date of 2019-01-01 and an end date of 2019-08-01:

<img width="874" alt="screen shot 2018-06-11 at 8 03 58 am" src="https://user-images.githubusercontent.com/8291663/41233389-ea847912-6d4e-11e8-82a8-1c6178bbb89b.png">
