### PR TITLE
Handle reqs XLSX file in script, closing #14

### DIFF
--- a/gather-info
+++ b/gather-info
@@ -326,22 +326,8 @@ def main():
                      % (len(features), len(all_requirements)))
     sys.stderr.write("\n")
 
-    ##### Get PSM requirements from the prepared CSV file. #####
-    #
-    # TODO: This is a bit ugly.  The refresh-dashboard script
-    # grep-parses the psm-dashboard-config.json file to find out the
-    # location of RTM.xlsx, produces RTM.csv from that, and leaves
-    # RTM.cvs in the current directory for us to pick up.  That's a
-    # lot of non-explicit interdependency.  
-    #
-    # An alternative would be for this program to read the config
-    # parameter 'psm_reqs' and run xlsx2csv on RTM.xlsx itself.  We
-    # would then be justified in knowing where the resultant CSV is
-    # because we would have created it.  But I didn't want to deal
-    # with the hassle of doing the following in Python: checking for
-    # xlsx2csv, warning if it's not present, otherwise running it.
-    # That's all a lot easier in shell.  So, we live with the kluge.
-    reqs = psm_reqs.get_reqs("RTM.csv")
+    ##### Get PSM requirements from the config XLSX file. #####
+    reqs = psm_reqs.get_reqs(config['psm_reqs'])
 
     ##### Get the issue<->req mapping from GitHub. #####
     github_owner_name = config['github_owner']

--- a/refresh-dashboard
+++ b/refresh-dashboard
@@ -23,38 +23,6 @@ if [ ! -f psm-dashboard-config.json ]; then
   exit 1
 fi
 
-# See issue #14.  Until that is resolved, we "parse" the JSON config
-# file here in shell, using grep and friends to get the value.
-RTM_XLSX=`grep '"psm_reqs":' psm-dashboard-config.json | sed -E 's/^ +"psm_reqs": +//g' | sed -E 's/"//g' | sed -E 's/, *$//'`
-
-RTM_XLSX_DIR=`dirname "${RTM_XLSX}"`
-SAVED_CWD=`pwd`
-cd ${RTM_XLSX_DIR}
-RTM_XLSX_DIR_BRANCH=`git branch | grep '^* ' | cut -c3-`
-cd ${SAVED_CWD}
-if [ "${RTM_XLSX_DIR_BRANCH}" != "master" ]; then
-  echo "ERROR: PSM tree is not on 'master' branch"
-  echo ""
-  echo "Your PSM repository clone must be on the 'master' branch, so"
-  echo "that we get the right version of the requirements spreadsheet."
-  exit 1
-fi
-
-if [ ! -f "${RTM_XLSX}" ]; then
-  echo "ERROR: can't find RTM.xlsx"
-  echo ""
-  echo "You must set the 'psm_reqs' parameter in 'psm-dashboard-config.json'"
-  echo "to point to the requirements/RTM.xlsx spreadsheet that lives in"
-  echo "the PSM tree."
-  exit 1
-fi
-
-echo ""
-echo "Converting requirements to CSV format..."
-xlsx2csv -s 0 "${RTM_XLSX}" > RTM.csv
-echo "Done."
-echo ""
-
 echo ""
 echo "Fetching and combining data (this can take a long time)..."
 ./gather-info > $$-features-info.json.tmp


### PR DESCRIPTION
Instead of using `xlsx2csv` as a script, this calls the `Xlsx2csv` class directly to write the CSV data to a `StringIO` object. The XLSX file path is loaded directly from the config file, and the same error from the refresh-dashboard script is thrown if the file doesn't exist. Most of the change is whitespace from removing the indentation where we were using it for the CSV context manager 